### PR TITLE
オブジェクトプールのリファクタリング

### DIFF
--- a/Assets/BulletPool.cs
+++ b/Assets/BulletPool.cs
@@ -1,16 +1,15 @@
-using System;
 using UnityEngine;
 using UnityEngine.Pool;
 
 public class BulletPool : MonoBehaviour
 {
-    private IObjectPool<Bullet> _bulletPool;
+    private PoolBase<Bullet> _bulletPool;
 
     [SerializeField] private Bullet bulletPrefab;
 
 
     private void Awake() {
-        _bulletPool = new ObjectPool<Bullet>
+        _bulletPool = new PoolBase<Bullet>
             (
                 createFunc: CreateBullet,
                 actionOnGet: bullet => bullet.gameObject.SetActive(true),
@@ -30,17 +29,19 @@ public class BulletPool : MonoBehaviour
     }
 
     public Bullet GetBullet() {
-        
+
         // 通常の方法
         //Bullet bullet = _bulletPool.Get();
         //bullet.BulletPool = this;
 
         //out修飾子でbulletを取り出し、返り値をIDisposableとして取得する
-        IDisposable disposable = _bulletPool.Get(out var bullet);
+        //IDisposable disposable = _bulletPool.Get(out var bullet);
+
+        (PooledObjClass<Bullet> pooledObject, Bullet bullet) = _bulletPool.Get();
 
         // 取得したbulletのインスタンスに、プールへの返却機能を渡す
         // 利点は Bullet 側には IDisposable のみ用意すればよいこと(仮に Objectpool の型が変わっても影響がない)
-        bullet.SetReturner(disposable);
+        bullet.SetReturner(pooledObject);
 
         // 呼び出し側にBulletのインスタンスを返す
         return bullet;

--- a/Assets/PoolBase.cs
+++ b/Assets/PoolBase.cs
@@ -1,0 +1,67 @@
+using System;
+using UnityEngine.Pool;
+
+/// <summary>
+/// オブジェクトプールの Get メソッドの戻り値を PooledObjectClass に変更したクラス
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class PoolBase<T> : IDisposable where T : class {
+
+    private readonly ObjectPool<T> _pool;
+    private int _countInactive;
+
+
+    /// <summary>
+    /// コンストラクタ
+    /// 内部で ObjectPool の初期化を行う形でラップしている
+    /// </summary>
+    /// <param name="createFunc"></param>
+    /// <param name="actionOnGet"></param>
+    /// <param name="actionOnRelease"></param>
+    /// <param name="actionOnDestroy"></param>
+    /// <param name="collectionCheck"></param>
+    /// <param name="maxSize"></param>
+    public PoolBase(
+        Func<T> createFunc,
+        Action<T> actionOnGet = null,
+        Action<T> actionOnRelease = null,
+        Action<T> actionOnDestroy = null,
+        bool collectionCheck = true,
+        int maxSize = 10000) {
+        _pool = new ObjectPool<T>(
+            createFunc: createFunc,
+            actionOnGet: actionOnGet,
+            actionOnRelease: actionOnRelease,
+            actionOnDestroy: actionOnDestroy,
+            collectionCheck: collectionCheck,
+            maxSize: maxSize);
+    }
+
+    /// <summary>
+    /// 通常の Get メソッドの代わりに使い、PooledObject 構造体ではなく PooledObjClass クラスを取得する
+    /// タプルにより、また生成したオブジェクトの情報も取得する
+    /// </summary>
+    /// <returns></returns>
+    public (PooledObjClass<T> pooledObject, T obj) Get() {
+        T value = _pool.Get();
+        return (new PooledObjClass<T>(value, _pool), value);
+    }
+
+    /// <summary>
+    /// IDisposable の Dispose を実行することでオブジェクトをプールに返却できる
+    /// オブジェクト自体がオブジェクトプールへの依存関係を持たないように設計できる
+    /// </summary>
+    public void Dispose() {
+        _pool.Dispose();
+    }
+
+    public void Release(T element) {
+        _pool.Release(element);
+    }
+
+    public void Clear() {
+        _pool.Clear();
+    }
+
+    public int CountInactive => _countInactive;
+}

--- a/Assets/PoolBase.cs.meta
+++ b/Assets/PoolBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bdf7a7864724a0459c729f1b705d0e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PooledObjClass.cs
+++ b/Assets/PooledObjClass.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace UnityEngine.Pool {
+
+    public class PooledObjClass<T> : IDisposable where T : class {
+
+        private readonly T m_ToReturn;
+        private readonly IObjectPool<T> m_Pool;
+
+        public PooledObjClass(T value, IObjectPool<T> pool) {
+            m_ToReturn = value;
+            m_Pool = pool;
+        }
+
+        public void Dispose() => m_Pool.Release(m_ToReturn);
+    }
+}

--- a/Assets/PooledObjClass.cs.meta
+++ b/Assets/PooledObjClass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52e127095d277754888c1b01380d8e35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,37 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &132212967
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 132212968}
+  m_Layer: 0
+  m_Name: GameObject (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &132212968
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 132212967}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 9.65, y: 0, z: 7.07}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 466761724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &221414562
 GameObject:
   m_ObjectHideFlags: 0
@@ -2162,6 +2193,71 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &466761723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 466761724}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &466761724
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 466761723}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1106732219}
+  - {fileID: 132212968}
+  - {fileID: 668799234}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &668799233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 668799234}
+  m_Layer: 0
+  m_Name: GameObject (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &668799234
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 668799233}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.16, y: 0, z: 7.07}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 466761724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &692886254
 GameObject:
   m_ObjectHideFlags: 3
@@ -2672,6 +2768,37 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &1106732218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1106732219}
+  m_Layer: 0
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1106732219
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106732218}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 9.65, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 466761724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1220763833
 GameObject:
   m_ObjectHideFlags: 0
@@ -3213,6 +3340,156 @@ Transform:
   - {fileID: 692886255}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 47.613, y: -0.41, z: 0}
+--- !u!1 &1441556428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1441556434}
+  - component: {fileID: 1441556433}
+  - component: {fileID: 1441556432}
+  - component: {fileID: 1441556431}
+  - component: {fileID: 1441556430}
+  - component: {fileID: 1441556429}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1441556429
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441556428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f9ac1469782a954a9311176999e1bfa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targets:
+  - {fileID: 1106732219}
+  - {fileID: 132212968}
+  - {fileID: 668799234}
+  speed: 3
+--- !u!143 &1441556430
+CharacterController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441556428}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Height: 1
+  m_Radius: 0.5
+  m_SlopeLimit: 45
+  m_StepOffset: 0.3
+  m_SkinWidth: 0.08
+  m_MinMoveDistance: 0.001
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &1441556431
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441556428}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1441556432
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441556428}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1441556433
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441556428}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1441556434
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1441556428}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1449497855
 GameObject:
   m_ObjectHideFlags: 0
@@ -3382,3 +3659,5 @@ SceneRoots:
   - {fileID: 854356773}
   - {fileID: 1220763838}
   - {fileID: 1898176653}
+  - {fileID: 466761724}
+  - {fileID: 1441556434}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -3324,37 +3324,6 @@ LightingSettings:
   m_PVRTiledBaking: 0
   m_NumRaysToShootPerTexel: -1
   m_RespectSceneVisibilityWhenBakingGI: 0
---- !u!1 &1789839497
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1789839498}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1789839498
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1789839497}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1898176652
 GameObject:
   m_ObjectHideFlags: 0
@@ -3408,7 +3377,6 @@ SceneRoots:
   - {fileID: 705507995}
   - {fileID: 454718386}
   - {fileID: 221414568}
-  - {fileID: 1789839498}
   - {fileID: 1427167302}
   - {fileID: 1449497857}
   - {fileID: 854356773}


### PR DESCRIPTION
・PooledObjClass.cs 作成。Unity の用意している PooledObject か構造体のため、
　ボックス化を避ける目的で PooledObject のクラス作成。

・PoolBase.cs 作成。ObjectPool を継承せずメンバ変数として用意し、コンストラクタに ObjectPool の初期化機能を自作。

・BulletPool.cs 修正。PoolBase を利用する方式に変更。